### PR TITLE
aws: improve handling of default tags

### DIFF
--- a/modules/aws/aurora/main.tf
+++ b/modules/aws/aurora/main.tf
@@ -60,7 +60,7 @@ locals {
     "rds.amazonaws.com"
   ])
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/aurora/main.tf
+++ b/modules/aws/aurora/main.tf
@@ -7,8 +7,8 @@
 ########################################################################
 
 data "aws_region" "current" {}
-
 data "aws_caller_identity" "current" {}
+data "aws_default_tags" "these" {}
 
 ########################################################################
 #                                                                      #
@@ -59,6 +59,8 @@ locals {
     data.aws_region.current.name,
     "rds.amazonaws.com"
   ])
+
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/aurora/main.tf
+++ b/modules/aws/aurora/main.tf
@@ -63,7 +63,7 @@ locals {
     "rds.amazonaws.com"
   ])
 
-  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
+  tags = merge(var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/aurora/main.tf
+++ b/modules/aws/aurora/main.tf
@@ -22,11 +22,14 @@ locals {
   aws_region_shortname = replace(data.aws_region.current.name, "/(\\w\\w).*-(\\w).*-(\\d).*$/", "$1$2$3")
   aws_account_id       = data.aws_caller_identity.current.account_id
 
+  namespace   = try(data.aws_default_tags.these.tags["Namespace"], var.namespace)
+  environment = try(data.aws_default_tags.these.tags["Namespace"], var.environment)
+
   # This generates a random value that will change when any of these other variables will change.
   # Trying playing with the sha256 function in the `terraform console`.
-  string_used_for_fake_ids = sha256(join("", [var.namespace, var.environment, local.aws_region_shortname, var.vpc_id]))
+  string_used_for_fake_ids = sha256(join("", [local.namespace, local.environment, local.aws_region_shortname, local.vpc_id]))
 
-  aurora_cluster_name = join("-", [var.namespace, var.environment, local.aws_region_shortname, "aurora", var.engine_name])
+  aurora_cluster_name = join("-", [local.namespace, local.environment, local.aws_region_shortname, "aurora", local.engine_name])
 
   aurora_cluster_arn = join(":", [
     "arn:aws:rds",
@@ -60,7 +63,7 @@ locals {
     "rds.amazonaws.com"
   ])
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
+  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/aurora/outputs.tf
+++ b/modules/aws/aurora/outputs.tf
@@ -51,5 +51,5 @@ output "port" {
 }
 
 output "tags" {
-  value = var.tags
+  value = local.tags
 }

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -7,8 +7,8 @@
 ########################################################################
 
 data "aws_region" "current" {}
-
 data "aws_caller_identity" "current" {}
+data "aws_default_tags" "these" {}
 
 ########################################################################
 #                                                                      #
@@ -49,6 +49,8 @@ locals {
     data.aws_region.current.name,
     "eks.amazonaws.com"
   ])
+
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -50,7 +50,7 @@ locals {
     "eks.amazonaws.com"
   ])
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -53,7 +53,7 @@ locals {
     "eks.amazonaws.com"
   ])
 
-  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
+  tags = merge(var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -22,11 +22,14 @@ locals {
   aws_region_shortname = replace(data.aws_region.current.name, "/(\\w\\w).*-(\\w).*-(\\d).*$/", "$1$2$3")
   aws_account_id       = data.aws_caller_identity.current.account_id
 
+  namespace   = try(data.aws_default_tags.these.tags["Namespace"], var.namespace)
+  environment = try(data.aws_default_tags.these.tags["Namespace"], var.environment)
+
   # This generates a random value that will change when any of these other variables will change.
   # Trying playing with the sha256 function in the `terraform console`.
-  string_used_for_fake_ids = sha256(join("", [var.namespace, var.environment, local.aws_region_shortname, var.vpc_id]))
+  string_used_for_fake_ids = sha256(join("", [local.namespace, local.environment, local.aws_region_shortname, local.vpc_id]))
 
-  eks_cluster_name = join("-", [var.namespace, var.environment, local.aws_region_shortname, "eks"])
+  eks_cluster_name = join("-", [local.namespace, local.environment, local.aws_region_shortname, "eks"])
 
   eks_cluster_arn = join(":", [
     "arn:aws:eks",
@@ -50,7 +53,7 @@ locals {
     "eks.amazonaws.com"
   ])
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
+  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -26,14 +26,6 @@ output "aws_region_shortname" {
   value = local.aws_region_shortname
 }
 
-output "environment" {
-  value = var.environment
-}
-
-output "namespace" {
-  value = var.namespace
-}
-
 output "vpc_id" {
   value = var.vpc_id
 }

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -39,5 +39,5 @@ output "vpc_id" {
 }
 
 output "tags" {
-  value = var.tags
+  value = local.tags
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -8,6 +8,7 @@
 
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_default_tags" "these" {}
 
 data "aws_availability_zones" "available" {
   state = "available"
@@ -66,7 +67,7 @@ locals {
     local.subnet_ids[m] => cidrsubnet(var.cidr_block, local.az_count, m)
   }
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags)
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -67,7 +67,7 @@ locals {
     local.subnet_ids[m] => cidrsubnet(var.cidr_block, local.az_count, m)
   }
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, aws_default_tags.these.tags)
+  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -70,7 +70,7 @@ locals {
     local.subnet_ids[m] => cidrsubnet(var.cidr_block, local.az_count, m)
   }
 
-  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
+  tags = merge({ namespace = local.namespace, environment = local.environment }, var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -70,7 +70,7 @@ locals {
     local.subnet_ids[m] => cidrsubnet(var.cidr_block, local.az_count, m)
   }
 
-  tags = merge({ namespace = local.namespace, environment = local.environment }, var.tags, data.aws_default_tags.these.tags)
+  tags = merge(var.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -26,11 +26,14 @@ locals {
   aws_region_shortname = replace(data.aws_region.current.name, "/(\\w\\w).*-(\\w).*-(\\d).*$/", "$1$2$3")
   aws_account_id       = data.aws_caller_identity.current.account_id
 
+  namespace   = try(data.aws_default_tags.these.tags["Namespace"], var.namespace)
+  environment = try(data.aws_default_tags.these.tags["Namespace"], var.environment)
+
   # This generates a random value that will change when any of these other variables will change.
   # Trying playing with the sha256 function in the `terraform console`.
-  string_used_for_fake_ids = sha256(join("", [var.namespace, var.environment, local.aws_region_shortname, var.cidr_block, local.available_az_count]))
+  string_used_for_fake_ids = sha256(join("", [local.namespace, local.environment, local.aws_region_shortname, var.cidr_block, local.available_az_count]))
 
-  vpc_name = join("-", [var.namespace, var.environment, local.aws_region_shortname, "vpc"])
+  vpc_name = join("-", [local.namespace, local.environment, local.aws_region_shortname, "vpc"])
   vpc_id   = join("-", ["vpc", substr(local.string_used_for_fake_ids, 0, 7)])
 
   available_az_count = length(data.aws_availability_zones.available.names)
@@ -49,8 +52,8 @@ locals {
   subnet_names = { for k in range(length(local.subnet_ids)) :
     local.subnet_ids[k] => join("-",
       [
-        var.namespace,
-        var.environment,
+        local.namespace,
+        local.environment,
         local.aws_region_shortname,
         (contains(split("", tostring(k / 2)), ".") ? "public" : "private"),
         "subnet",
@@ -67,7 +70,7 @@ locals {
     local.subnet_ids[m] => cidrsubnet(var.cidr_block, local.az_count, m)
   }
 
-  tags = merge({ namespace = var.namespace, environment = var.environment }, var.tags, data.aws_default_tags.these.tags)
+  tags = merge({ namespace = local.namespace, environment = local.environment }, local.tags, data.aws_default_tags.these.tags)
 }
 
 ########################################################################

--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -30,14 +30,6 @@ output "aws_region_shortname" {
   value = local.aws_region_shortname
 }
 
-output "environment" {
-  value = var.environment
-}
-
-output "namespace" {
-  value = var.namespace
-}
-
 output "tags" {
   value = local.tags
 }


### PR DESCRIPTION
This will make using the AWS provider's `default_tags` block smoother instead of cobbling strings together from input variables. 